### PR TITLE
site.conf: remove file in favor of a dedicated classes

### DIFF
--- a/classes/stm32mp1.bbclass
+++ b/classes/stm32mp1.bbclass
@@ -1,5 +1,3 @@
-# site.conf is used for configuration settings
-
 # Use systemd as init system
 VIRTUAL-RUNTIME_init_manager = "systemd"
 DISTRO_FEATURES_BACKFILL_CONSIDERED = "sysvinit"

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -16,3 +16,5 @@ BBFILES_DYNAMIC += " \
     openembedded-layer:${LAYERDIR}/dynamic-layers/openembedded-layer/*/*/*.bb \
     openembedded-layer:${LAYERDIR}/dynamic-layers/openembedded-layer/*/*/*.bbappend \
 "
+
+INHERIT += "stm32mp1"


### PR DESCRIPTION
There is no need to use the site.conf here.

Signed-off-by: Pierre-Jean Texier <pjtexier@koncepto.io>