### PR TITLE
stm32mp1.bbclass: add openssh-sftp-server to IMAGE_INSTALL list

### DIFF
--- a/classes/stm32mp1.bbclass
+++ b/classes/stm32mp1.bbclass
@@ -16,7 +16,7 @@ DISTRO_FEATURES_remove = " \
 "
 
 IMAGE_INSTALL_append = " \
-	i2c-tools u-boot-mainline-initial-env \
+	i2c-tools u-boot-mainline-initial-env openssh-sftp-server \
 "
 
 IMAGE_FEATURES_append = " \


### PR DESCRIPTION
QtCreator uses sftp deployment (instead of scp) to "Generic embedded
Linux" devices.

Signed-off-by: Pierre-Jean Texier <pjtexier@koncepto.io>
Reviewed-by: Joris Offouga offougajoris@gmail.com
(cherry picked from commit a5ee03126197d707a2010806e33de8cc55804ecd)
Signed-off-by: Pierre-Jean Texier <pjtexier@koncepto.io>
