### PR TITLE
qt5/core-image-base: add inherit populate_sdk_qt5 directive

### DIFF
--- a/dynamic-layers/qt5-layer/recipes-qt/images/core-image-base.bbappend
+++ b/dynamic-layers/qt5-layer/recipes-qt/images/core-image-base.bbappend
@@ -1,3 +1,5 @@
+inherit populate_sdk_qt5
+
 IMAGE_INSTALL_append = " \
 	packagegroup-qt5 \
 "


### PR DESCRIPTION
Add inherit populate_sdk_qt5 to core-image-base image recipe.
This allows to support required development tools for
cross-compiling a Qt application (qmake, etc)

Example:
 $: bitbake core-image-base -c populate_sdk

Signed-off-by: Pierre-Jean Texier <pjtexier@koncepto.io>