### PR TITLE
kas: remove duplicate rm_work assignment

### DIFF
--- a/kas-master.yml
+++ b/kas-master.yml
@@ -31,7 +31,6 @@ local_conf_header:
     SDKMACHINE = "x86_64"
     USER_CLASSES = "buildstats image-mklibs image-prelink"
     PATCHRESOLVE = "noop"
-    INHERIT += "rm_work"
   debug-tweaks: |
     EXTRA_IMAGE_FEATURES = "debug-tweaks"
   diskmon: |


### PR DESCRIPTION
We already have INHERIT += "rm_work_and_downloads"

Signed-off-by: Pierre-Jean Texier <pjtexier@koncepto.io>