### PR TITLE
wic: rename U-Boot partition from 'uboot' to 'ssbl'

### DIFF
--- a/wic/stm32mp1.wks
+++ b/wic/stm32mp1.wks
@@ -3,7 +3,7 @@
 
 part fsbl1 --source rawcopy --sourceparams="file=u-boot-spl.stm32" --ondisk mmcblk --align 1 --size 256k --part-name fsbl1
 part fsbl2 --source rawcopy --sourceparams="file=u-boot-spl.stm32" --ondisk mmcblk --align 1 --size 256k --part-name fsbl2
-part u-boot --source rawcopy --sourceparams="file=u-boot.img" --ondisk mmcblk --align 1 --size 2M --part-name uboot
+part ssbl --source rawcopy --sourceparams="file=u-boot.img" --ondisk mmcblk --align 1 --size 2M --part-name ssbl
 
 part / --source rootfs --ondisk mmcblk --fstype=ext4 --label root --align 1 --size 256M --active
 


### PR DESCRIPTION
This to follow the U-Boot requirements, see:

https://gitlab.denx.de/u-boot/u-boot/blob/master/board/st/stm32mp1/README

Signed-off-by: Pierre-Jean Texier <pjtexier@koncepto.io>