### PR TITLE
stm32mp1.bbclass: Fix u-boot-initial-env

### DIFF
--- a/classes/stm32mp1.bbclass
+++ b/classes/stm32mp1.bbclass
@@ -16,7 +16,7 @@ DISTRO_FEATURES_remove = " \
 "
 
 IMAGE_INSTALL_append = " \
-	i2c-tools u-boot-initial-env openssh-sftp-server \
+	i2c-tools u-boot-env openssh-sftp-server \
 "
 
 IMAGE_FEATURES_append = " \


### PR DESCRIPTION
With 8fad804e u-boot-initial-env steps has been remove instead oe-core implementation
This fact u-boot-initial-env is provide by u-boot-env package

Signed-off-by: Joris Offouga <offougajoris@gmail.com>
