### PR TITLE
wic: Remove metadata_csum option

### DIFF
--- a/conf/machine/include/stm32mp1.inc
+++ b/conf/machine/include/stm32mp1.inc
@@ -18,7 +18,7 @@ KERNEL_IMAGETYPE ?= "zImage"
 WIC_CREATE_EXTRA_ARGS ?= "--no-fstab-update"
 
 # Image
-IMAGE_FSTYPES += "tar.bz2 wic wic.gz wic.bmap"
+IMAGE_FSTYPES += "tar.bz2 wic wic.gz wic.bmap ext4 ext4.gz"
 
 WKS_FILE_DEPENDS ?= " \
     virtual/bootloader \
@@ -28,3 +28,8 @@ WKS_FILE_DEPENDS ?= " \
 
 # Wic default support
 WKS_FILE ?= "stm32mp1.wks"
+
+# Define specific EXT4 command line:
+#   - Create minimal inode number (as it is done by default in image_types.bbclass)
+#   - Deactivate metadata_csum not supported by U-Boot
+EXTRA_IMAGECMD_ext4 = "-i 4096 -O ^metadata_csum"

--- a/wic/stm32mp1.wks
+++ b/wic/stm32mp1.wks
@@ -5,6 +5,6 @@ part fsbl1 --source rawcopy --sourceparams="file=u-boot-spl.stm32" --ondisk mmcb
 part fsbl2 --source rawcopy --sourceparams="file=u-boot-spl.stm32" --ondisk mmcblk --align 1 --size 256k --part-name fsbl2
 part ssbl --source rawcopy --sourceparams="file=u-boot.img" --ondisk mmcblk --align 1 --size 2M --part-name ssbl
 
-part / --source rootfs --ondisk mmcblk --fstype=ext4 --label root --align 1 --size 256M --active
+part / --source rootfs --ondisk mmcblk --fstype=ext4 --mkfs-extraopts="-i 4096 -O ^metadata_csum" --label root --align 1 --size 256M --active
 
 bootloader --ptable gpt


### PR DESCRIPTION
With commit https://github.com/bdx-iot/meta-stm32mp1/commit/8fad804ee671e45afb955ae6be59d3fc2a8c3830
The U-Boot environment is now stored in the ext4 partition, but U-Boot does not support the
metadata_csum option and therefore cannot save the environment and this also causes kernel panic:

U-Boot log :
Unsupported feature metadata_csum found, not writing.

** Unable to write "/uboot.env" from mmc0:4 **
Failed (1)

Kernel log :
[    3.336360] EXT4-fs (mmcblk0p4): VFS: Found ext4 filesystem with invalid superblock checksum.  Run e2fsck?
[    3.344780] VFS: Cannot open root device "mmcblk0p4" or unknown-block(179,4): error -74


Signed-off-by: Joris Offouga <offougajoris@gmail.com>