### PR TITLE
u-boot: refresh patch to work with version 2020.07

### DIFF
--- a/recipes-bsp/u-boot/u-boot/0001-stm32mp1-Disable-ADC.patch
+++ b/recipes-bsp/u-boot/u-boot/0001-stm32mp1-Disable-ADC.patch
@@ -1,7 +1,7 @@
-From 6549afce14cfb2d99aa6227752ed1180197a8282 Mon Sep 17 00:00:00 2001
-From: Joris Offouga <offougajoris@gmail.com>
-Date: Mon, 10 Feb 2020 23:59:49 +0100
-Subject: [PATCH 1/2] stm32mp1: Disable ADC
+From 9646728ddb64e009fb41e01315fa07c198982e8f Mon Sep 17 00:00:00 2001
+From: Pierre-Jean Texier <pjtexier@koncepto.io>
+Date: Sun, 26 Jul 2020 15:35:39 +0000
+Subject: [PATCH] stm32mp1: Disable ADC
 
 Signed-off-by: Pierre-Jean Texier <pjtexier@koncepto.io>
 Signed-off-by: Joris Offouga <offougajoris@gmail.com>
@@ -10,13 +10,13 @@ Signed-off-by: Joris Offouga <offougajoris@gmail.com>
  1 file changed, 1 insertion(+), 2 deletions(-)
 
 diff --git a/configs/stm32mp15_basic_defconfig b/configs/stm32mp15_basic_defconfig
-index 713a7e6c57..917078ffa6 100644
+index 3bd8434d26..d397b8d19e 100644
 --- a/configs/stm32mp15_basic_defconfig
 +++ b/configs/stm32mp15_basic_defconfig
-@@ -26,7 +26,6 @@ CONFIG_SYS_PROMPT="STM32MP> "
- # CONFIG_CMD_IMPORTENV is not set
- CONFIG_CMD_MEMINFO=y
+@@ -29,7 +29,6 @@ CONFIG_CMD_MEMINFO=y
  CONFIG_CMD_MEMTEST=y
+ CONFIG_SYS_MEMTEST_START=0xc0000000
+ CONFIG_SYS_MEMTEST_END=0xc4000000
 -CONFIG_CMD_ADC=y
  CONFIG_CMD_CLK=y
  CONFIG_CMD_DFU=y
@@ -26,10 +26,10 @@ index 713a7e6c57..917078ffa6 100644
  CONFIG_ENV_UBI_VOLUME_REDUND="uboot_config_r"
  CONFIG_SYS_RELOC_GD_ENV_ADDR=y
 -CONFIG_STM32_ADC=y
- CONFIG_DFU_MMC=y
- CONFIG_DFU_RAM=y
- CONFIG_DFU_MTD=y
-@@ -109,6 +107,7 @@ CONFIG_PINCTRL_STMFX=y
+ CONFIG_SET_DFU_ALT_INFO=y
+ CONFIG_USB_FUNCTION_FASTBOOT=y
+ CONFIG_FASTBOOT_BUF_ADDR=0xC0000000
+@@ -108,6 +106,7 @@ CONFIG_PINCTRL_STMFX=y
  CONFIG_DM_PMIC=y
  # CONFIG_SPL_PMIC_CHILDREN is not set
  CONFIG_PMIC_STPMIC1=y
@@ -37,6 +37,6 @@ index 713a7e6c57..917078ffa6 100644
  CONFIG_DM_REGULATOR_FIXED=y
  CONFIG_DM_REGULATOR_GPIO=y
  CONFIG_DM_REGULATOR_STM32_VREFBUF=y
---
-2.20.1
+-- 
+2.17.1
 


### PR DESCRIPTION
To avoid the following build issue:

ERROR: Applying '0001-stm32mp1-Disable-ADC.patch' failed:
checking file configs/stm32mp15_basic_defconfig
Hunk #1 FAILED at 26.
Hunk #2 FAILED at 64.
Hunk #3 succeeded at 108 (offset -1 lines).
2 out of 3 hunks FAILED

Fixes: 714143d0cfa52d2b5a37d52d090cba09f0dcd8db ("u-boot: bump to version 2020.07")

Signed-off-by: Pierre-Jean Texier <pjtexier@koncepto.io>